### PR TITLE
Fix handle name for Windows 10.

### DIFF
--- a/src/ofxWin8Touch.cpp
+++ b/src/ofxWin8Touch.cpp
@@ -185,5 +185,5 @@ void ofxWin8TouchSetup() {
 		return;
 	}
 
-	prevWndProc = (WNDPROC)SetWindowLongPtr(hwnd, GWL_WNDPROC, (LONG_PTR)pointerWndProc);
+	prevWndProc = (WNDPROC)SetWindowLongPtr(hwnd, GWLP_WNDPROC, (LONG_PTR)pointerWndProc);
 }


### PR DESCRIPTION
Code was not compiling until I changed the windows handle type. 

Found some info here: https://stackoverflow.com/questions/51771072/gwl-wndproc-undeclared

This works for me in both 32-bit and 64-bit on Windows 10.